### PR TITLE
Deprecate 8.0, 9.0 and 10.0 👴

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,12 +28,6 @@ jobs:
             test: false
           - odoo: "11.0"
             test: false
-          - odoo: "10.0"
-            test: false
-          - odoo: "9.0"
-            test: false
-          - odoo: "8.0"
-            test: false
 
     steps:
       -


### PR DESCRIPTION
These images are not support, built nor released anymore.
If you need them, you can always [pull a previously release version](https://github.com/odoo-it/docker-odoo/pkgs/container/docker-odoo/versions).