### PR TITLE
[IMP] ci cache: each version using their own separate cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,7 @@ jobs:
             wkhtmltopdf_version: "0.12.5"
             test: true
     env:
+      CACHE_KEY: ${{ matrix.odoo }}_${{ matrix.dist }}_py${{ matrix.py }}_wkhtmltopdf${{ matrix.wkhtmltopdf_version }}
       BUILD_ARGS: |
         ODOO_VERSION=${{ matrix.odoo }}
         DISTRIBUTION=${{ matrix.dist }}
@@ -82,8 +83,8 @@ jobs:
           build-args: ${{ env.BUILD_ARGS }}
           tags: ${{ github.repository }}:${{ matrix.odoo }}
           labels: org.opencontainers.image.source=${{ github.event.repository.html_url }}
-          cache-from: type=gha,scope=ci
-          cache-to: type=gha,mode=max,scope=ci
+          cache-from: type=gha,scope=${{ env.CACHE_KEY }}
+          cache-to: type=gha,mode=max,scope=${{ env.CACHE_KEY }}
           load: true
       -
         name: Test
@@ -102,8 +103,6 @@ jobs:
           build-args: ${{ env.BUILD_ARGS }}
           tags: ghcr.io/${{ github.repository }}:${{ matrix.odoo }}-latest
           labels: org.opencontainers.image.source=${{ github.event.repository.html_url }}
-          cache-from: type=gha,scope=ci
-          cache-to: type=gha,mode=max,scope=ci
           push: true
       -
         name: Release
@@ -115,6 +114,4 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ matrix.odoo }}
             ghcr.io/${{ github.repository }}:${{ matrix.odoo }}.${{ github.event.release.tag_name }}
           labels: org.opencontainers.image.source=${{ github.event.repository.html_url }}
-          cache-from: type=gha,scope=ci
-          cache-to: type=gha,mode=max,scope=ci
           push: true


### PR DESCRIPTION
This should prevent the cache from being overwritten by different versions, and thus increase the cache hits