### PR TITLE
[FIX] docker image tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,14 +64,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
-          flavor: |
-            latest=auto
-            prefix=${{ matrix.odoo }}-
           tags: |
-            type=ref,event=tag
+            type=ref,event=tag,prefix=${{ matrix.odoo }}.
+            type=ref,event=tag,value=${{ matrix.odoo }}
             type=ref,event=pr,prefix=${{ matrix.odoo }}-pr-
             type=sha,prefix=${{ matrix.odoo }}-
-            type=raw,value=unstable,prefix=${{ matrix.odoo }}-,enable={{is_default_branch}}
+            type=raw,value=latest,prefix=${{ matrix.odoo }}-,enable={{is_default_branch}}
       -
         name: Prepare Bake Target
         id: target


### PR DESCRIPTION
The previous fix was wrong. Here's the correct schema:

* `x.x.x.x.x` points to a specific released version (e.g: `17.0.2.0.1`)
* `x.x` points to the latest released version (e.g: `17.0`)
* `latest` points to the latest unreleased commit (e.g: `17.0-latest`)
* `x.x-sha` points to a specific commit (e.g: `17.0-1a2b3c4d`)