### PR TITLE
[FIX] gevent build failure with python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY --chmod=700 build/ /build/
 RUN apt-get -qq update \
     && xargs -a /build/install/${DISTRIBUTION}/apt-build-deps.txt apt-get install -yqq --no-install-recommends \
     # Python Packages
-    && pip install --no-cache-dir \
+    && pip install --no-cache-dir --prefer-binary \
         --requirement /build/odoo/requirements.txt \
         --requirement /build/requirements.txt \
         --requirement /build/extra-requirements.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ ADD https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.tx
 COPY --chmod=700 build/ /build/
 RUN apt-get -qq update \
     && xargs -a /build/install/${DISTRIBUTION}/apt-build-deps.txt apt-get install -yqq --no-install-recommends \
+    # disable gevent version recommendation from odoo and use 21.12.0 instead
+    && sed -i -E "s/gevent==21\.8\.0/gevent==21.12.0/" /build/odoo/requirements.txt \
     # Python Packages
     && pip install --no-cache-dir --prefer-binary \
         --requirement /build/odoo/requirements.txt \


### PR DESCRIPTION
More information: https://github.com/odoo/odoo/issues/187021

By switching to --prefer-binary, we avoid the error by simply not compiling from source. This is also a nice improvement, as it might speed up the build process for the other packages, too.