### PR TITLE
✨ odoorc: store `.odoorc` directly in home

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,18 +69,16 @@ COPY ${LOCAL_GEOIP_PATH}/GeoLite2-*.mmdb /usr/share/GeoIP/
 ENV SOURCES=/home/odoo/src
 ENV REPOSITORIES=$SOURCES/repositories
 ENV DATA_DIR=/home/odoo/data
-ENV CONFIG_DIR=/home/odoo/.config
 ENV RESOURCES=/home/odoo/.resources
 
 # Config env
 ENV ODOO_VERSION=$ODOO_VERSION
-ENV ODOO_RC=$CONFIG_DIR/odoo.conf
+ENV ODOO_RC=/home/odoo/.odoorc
 
 # Add odoo user and directories
 RUN useradd -md /home/odoo -s /bin/false odoo \
     && mkdir -p $REPOSITORIES \
     && mkdir -p $DATA_DIR \
-    && mkdir -p $CONFIG_DIR \
     && mkdir -p $RESOURCES \
     && chown -R odoo:odoo /home/odoo \
     && sync

--- a/README.md
+++ b/README.md
@@ -96,11 +96,10 @@ same. This is the structure:
         addons/
         filestore/
         sessions/
-    .config/
-        odoo.conf
     .resources/
         conf.d/
         entrypoint.d/
+    .odoorc
 
 | Path                      | Description                                                                                                   |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------- |
@@ -108,13 +107,13 @@ same. This is the structure:
 | `src/repositories`        | Optional. Path where your project's addon repositories are expected to be.                                    |
 | `src/user`                | Optional. Path where your project's local source is expected to be. Submodules will be loaded too.            |
 | `data/`                   | Odoo data directory. You usually want to persist it.                                                          |
-| `.config/odoo.conf`       | Odoo configuration file. Generated automatically from `conf.d`.                                               |
-| `.resources/conf.d`       | Files here will be environment-variable-expanded and concatenated in `odoo.conf` in the entrypoint.           |
+| `.resources/conf.d`       | Files here will be environment-variable-expanded and concatenated in the config file, during the entrypoint.  |
 | `.resources/entrypoint.d` | Any executables found here will be run when you launch your container.                                        |
+| `.odoorc`                 | Odoo configuration file. Generated automatically from `conf.d`.                                               |
 
 ### Runtime environment variables
 
-The following variables can customize entrypoint behaviour and `odoo.conf`:
+The following variables can customize entrypoint behaviour and odoo configuration:
 
 #### Odoo Configuration
 


### PR DESCRIPTION
In fact, Odoo already attempts to read from this file, so we may not even need the env variable.