### PR TITLE
Fix invalid timeout handling in wait script

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The following variables can customize entrypoint behaviour and odoo configuratio
 
 -   `ODOO_ADDONS_DISCOVERY_PATHS`: Comma-separated list of paths to discover addons in. Defaults to `~/src/user,~/src/repositories`.
 -   `AUTO_UPDATE_MODULES`: Run `click-odoo-update` to automatically update addons.
--   `PGTIMEOUT`: Seconds to wait for the postgres server to respond. Set to `0` to disable. (default: `10`)
+-   `PGTIMEOUT`: Integer number of seconds to wait for the postgres server to respond. Set to `0` to disable. (default: `10`)
 
 ## Development
 

--- a/entrypoint.d/600-wait-postgres
+++ b/entrypoint.d/600-wait-postgres
@@ -4,7 +4,13 @@ set -e
 # Default value (set to 0 to disable)
 PGTIMEOUT=${PGTIMEOUT:-10}
 
-if [ ${PGTIMEOUT:-10} -le 0 ]; then
+# Ensure the timeout is numeric
+if ! [[ "$PGTIMEOUT" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: PGTIMEOUT must be an integer" 1>&2
+    exit 1
+fi
+
+if [ "$PGTIMEOUT" -le 0 ]; then
     exit 0
 fi
 

--- a/other/welcome.sh
+++ b/other/welcome.sh
@@ -16,8 +16,8 @@ echo ""
 echo "You are running Odoo $(tput setaf 3)$ODOO_VERSION$(tput sgr0) connected to $(tput setaf 3)$PGDATABASE$(tput sgr0)."
 echo "The configuration file is $(tput setaf 3)$ODOO_RC$(tput sgr0), generated from $(tput setaf 3)$RESOURCES/conf.d$(tput sgr0)."
 
-# Print some usefull commands
+# Print some useful commands
 echo ""
-echo "Here are some usefull commands:"
+echo "Here are some useful commands:"
 echo "  $(tput setaf 6)odoo$(tput sgr0): Launch Odoo"
 echo "  $(tput setaf 6)psql$(tput sgr0): Connect to the database"


### PR DESCRIPTION
## Summary
- validate that `PGTIMEOUT` is numeric in `600-wait-postgres`
- fix typos in `welcome.sh`
- document that `PGTIMEOUT` must be an integer

------
https://chatgpt.com/codex/tasks/task_e_685fd0b9b798833082c1f119b592d850