### PR TITLE
✨ lint Dockerfiles with hadolint via pre-commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,17 @@ on:
 
 jobs:
 
+  pre-commit:
+    name: Pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v6
+      -
+        name: Run pre-commit hooks
+        uses: j178/prek-action@v2.0.4
+
   prepare:
     name: Prepare
     runs-on: ubuntu-latest

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,3 @@
+# Hadolint configuration — shared by pre-commit and CI.
+# https://github.com/hadolint/hadolint#configure
+failure-threshold: warning

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.14.0
+    hooks:
+      - id: hadolint-docker

--- a/README.md
+++ b/README.md
@@ -196,3 +196,23 @@ To include the GeoIP databases in the image, you can place the `GeoLite2-City.mm
 
 Alternatively, you can use the `LOCAL_GEOIP_PATH` argument to specify a path to the GeoIP
 databases. However, keep in mind that the path must be relative to the build directory.
+
+### Linting
+
+Dockerfiles are linted with [Hadolint](https://github.com/hadolint/hadolint), managed
+through [pre-commit](https://pre-commit.com/) hooks defined in `.pre-commit-config.yaml`.
+The shared Hadolint configuration lives in `.hadolint.yaml`. CI runs the same hooks, so
+what passes locally passes in CI.
+
+We use [prek](https://github.com/j178/prek), a faster drop-in replacement for the
+`pre-commit` CLI. Install the git hooks once and they'll run on every commit:
+
+```bash
+prek install
+```
+
+You can also run all hooks on demand:
+
+```bash
+prek run --all-files
+```

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,8 +2,9 @@ ARG DOCKER_REPO
 ARG DOCKER_TAG
 FROM $DOCKER_REPO:$DOCKER_TAG
 ARG ODOO_SOURCE=odoo/odoo
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mkdir -p /tmp/odoo \
-    && (curl -sSL https://github.com/$ODOO_SOURCE/tarball/$ODOO_VERSION | tar -C /tmp/odoo -xz) \
-    && mv /tmp/odoo/* $SOURCES/odoo \
+    && (curl -sSL "https://github.com/$ODOO_SOURCE/tarball/$ODOO_VERSION" | tar -C /tmp/odoo -xz) \
+    && mv /tmp/odoo/* "$SOURCES/odoo" \
     && rm -rf /tmp/odoo \
     && pip-install-odoo


### PR DESCRIPTION
## What

Add automated Dockerfile linting with [Hadolint](https://github.com/hadolint/hadolint), wired through [pre-commit](https://pre-commit.com/) hooks so the same checks run locally and in CI.

## Changes

- **`.pre-commit-config.yaml`** — new, with the `hadolint-docker` hook (pinned to `v2.14.0`, no local hadolint install required).
- **`.hadolint.yaml`** — shared Hadolint config (single source of truth for local + CI), `failure-threshold: warning`.
- **`.github/workflows/ci.yaml`** — new `pre-commit` job that runs the hooks via [`prek`](https://github.com/j178/prek) (`j178/prek-action`), a faster drop-in for the `pre-commit` CLI. Keeps the hook set in one place so CI mirrors local.
- **`tests/Dockerfile`** — fix the findings hadolint surfaced:
  - `DL4006` — set `SHELL` with `-o pipefail` before the `curl … | tar` pipe.
  - `SC2086` — quote `$ODOO_SOURCE`/`$ODOO_VERSION` and `$SOURCES/odoo`.
- **`README.md`** — document linting under Development (`prek install`, `prek run --all-files`).

## Notes

- The main `Dockerfile` was already clean; only `tests/Dockerfile` needed fixes.
- Verified hadolint passes on both Dockerfiles with the shared config.