### PR TITLE
🔒 Warn at entrypoint when weak default secrets are in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ The following variables can customize entrypoint behaviour and odoo configuratio
 -   `ODOO_ADDONS_DISCOVERY_PATHS`: Comma-separated list of paths to discover addons in. Defaults to `~/src/user,~/src/repositories`.
 -   `AUTO_UPDATE_MODULES`: Run `click-odoo-update` to automatically update addons.
 -   `PGTIMEOUT`: Integer number of seconds to wait for the postgres server to respond. Set to `0` to disable. (default: `10`)
+-   `ODOO_SKIP_SECRET_WARNINGS`: Set to `true` to silence the warning shown at startup when weak default secrets are still in use (see below).
+
+> [!WARNING]
+> For convenience, this image ships with weak defaults that are **only suitable
+> for local development**: `ADMIN_PASSWORD` defaults to `admin` (the database
+> master password) and `PGPASSWORD` defaults to `odoo`. Always override these
+> before exposing an instance to production. The entrypoint prints a warning at
+> startup while these defaults remain in use.
 
 ## Development
 

--- a/entrypoint.d/300-warn-default-secrets
+++ b/entrypoint.d/300-warn-default-secrets
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+# Warn loudly when weak baked-in default secrets are still in use.
+# These defaults are convenient for local development but dangerous in
+# production. Set ODOO_SKIP_SECRET_WARNINGS=true to silence this check.
+
+if [ "${ODOO_SKIP_SECRET_WARNINGS:-}" = "true" ]; then
+    exit 0
+fi
+
+warnings=()
+
+# ADMIN_PASSWORD defaults to "admin" in 500-config-generate when unset.
+if [ -z "${ADMIN_PASSWORD:-}" ] || [ "$ADMIN_PASSWORD" = "admin" ]; then
+    warnings+=("ADMIN_PASSWORD is set to the default 'admin' (database master password)")
+fi
+
+# PGPASSWORD defaults to "odoo", baked into the image as an ENV.
+if [ "${PGPASSWORD:-}" = "odoo" ]; then
+    warnings+=("PGPASSWORD is set to the default 'odoo' (PostgreSQL password)")
+fi
+
+if [ ${#warnings[@]} -gt 0 ]; then
+    echo "" 1>&2
+    echo "⚠️  WARNING: weak default secrets detected" 1>&2
+    for warning in "${warnings[@]}"; do
+        echo "  - $warning" 1>&2
+    done
+    echo "  These defaults are fine for local development but MUST be" 1>&2
+    echo "  overridden before exposing this instance to production." 1>&2
+    echo "  Set ODOO_SKIP_SECRET_WARNINGS=true to silence this message." 1>&2
+    echo "" 1>&2
+fi


### PR DESCRIPTION
## What

Adds a startup warning when the image's weak baked-in default secrets are still in use, and documents these defaults loudly in the README.

The image ships with convenient-but-weak defaults that are only suitable for local development:
- `ADMIN_PASSWORD` defaults to `admin` (database master password, applied in `500-config-generate`)
- `PGPASSWORD` defaults to `odoo` (baked-in `ENV` in the `Dockerfile`)

These are fine for dev but risky if they reach production.

## Changes

- **New `entrypoint.d/300-warn-default-secrets`**: prints a warning to stderr early in the entrypoint sequence (before config generation) whenever `ADMIN_PASSWORD` is unset/`admin` or `PGPASSWORD` is `odoo`. Always exits `0` so it's safe under `run-parts --exit-on-error`. Suppressible via `ODOO_SKIP_SECRET_WARNINGS=true`.
- **`README.md`**: documents the new `ODOO_SKIP_SECRET_WARNINGS` variable and adds a warning callout about the default secrets.

## Testing

Verified the script across scenarios (both defaults, both secure, partial, and silenced) — output and exit codes are correct.