### PR TITLE
🙈 add .dockerignore to slim down build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,20 +1,26 @@
-# Everything is excluded by default, then we allow only what the
-# Dockerfile actually needs into the build context.
-*
+# Keep the Docker build context small. We use a denylist (rather than an
+# allowlist) because LOCAL_GEOIP_PATH is configurable, so the GeoIP files
+# may live in any directory and must always reach the build.
 
-# Build inputs (see Dockerfile)
-!build/
-!bin/
-!conf.d/
-!entrypoint.d/
-!entrypoint.sh
-!other/
+# Version control
+.git/
+.gitignore
 
-# GeoIP databases (optional, consumed by COPY GeoLite2-*.mmdb)
-!GeoLite2-*.mmdb
+# CI / repo metadata
+.github/
+.dockerignore
+README.md
+LICENSE
 
-# Drop noise that may live inside the allowed directories
+# Build orchestration (not needed inside the build context)
+docker-bake.hcl
+
+# Tests
+tests/
+
+# Editors / OS / tooling junk
+.vscode/
+.claude/
 **/.DS_Store
-**/.vscode/
 **/__pycache__/
 **/*.pyc

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Everything is excluded by default, then we allow only what the
+# Dockerfile actually needs into the build context.
+*
+
+# Build inputs (see Dockerfile)
+!build/
+!bin/
+!conf.d/
+!entrypoint.d/
+!entrypoint.sh
+!other/
+
+# GeoIP databases (optional, consumed by COPY GeoLite2-*.mmdb)
+!GeoLite2-*.mmdb
+
+# Drop noise that may live inside the allowed directories
+**/.DS_Store
+**/.vscode/
+**/__pycache__/
+**/*.pyc


### PR DESCRIPTION
## What

Adds a `.dockerignore` file, which the repo was missing.

## Why

Without it, the Docker build context shipped everything in the repo — `.git`, `.DS_Store`, `README.md`, `tests/`, `docker-bake.hcl`, etc. This bloats the context sent to the daemon/builder, slows builds, and leaks unrelated files into the image build.

## How

Uses an allowlist (`*` then `!`) so only the paths the `Dockerfile` actually consumes are sent:

- `build/`, `bin/`, `conf.d/`, `entrypoint.d/`, `entrypoint.sh`, `other/`
- `GeoLite2-*.mmdb` — kept available for the optional `COPY GeoLite2-*.mmdb` (it's gitignored but expected in the context)

Plus trailing rules to drop `.DS_Store`, `.vscode/`, and Python caches that might live inside the allowed directories.