### PR TITLE
🎨 Use odoo:odoo colon syntax in COPY --chown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,12 +89,12 @@ RUN useradd -md /home/odoo -s /bin/false odoo \
 
 # Entrypoint scripts
 COPY --chmod=777 bin/* /usr/local/bin/
-COPY --chown=odoo.odoo --chmod=777 conf.d $RESOURCES/conf.d
-COPY --chown=odoo.odoo --chmod=777 entrypoint.d $RESOURCES/entrypoint.d
-COPY --chown=odoo.odoo --chmod=777 entrypoint.sh $RESOURCES/entrypoint.sh
+COPY --chown=odoo:odoo --chmod=777 conf.d $RESOURCES/conf.d
+COPY --chown=odoo:odoo --chmod=777 entrypoint.d $RESOURCES/entrypoint.d
+COPY --chown=odoo:odoo --chmod=777 entrypoint.sh $RESOURCES/entrypoint.sh
 
 # Other files
-COPY --chown=odoo.odoo --chmod=777 other/welcome.sh /etc/profile.d/
+COPY --chown=odoo:odoo --chmod=777 other/welcome.sh /etc/profile.d/
 
 # Default values for postgres
 ENV PGHOST=db


### PR DESCRIPTION
## Summary
Replace the deprecated `--chown=odoo.odoo` dot syntax with the colon form `--chown=odoo:odoo` in the `COPY` instructions (Dockerfile:92-97).

The dot-separated `user.group` syntax is deprecated in favor of the `user:group` colon form, which is the documented standard for `chown` and Docker's `COPY --chown`.

## Changes
- `Dockerfile`: 4 `COPY --chown` instructions updated to use `odoo:odoo`.