### PR TITLE
🔥 drop pointless sync calls in build layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,7 @@ RUN --mount=type=bind,src=build/install/${DISTRIBUTION},dst=/build/install,rw \
     && xargs -a /build/install/apt-requirements.txt apt-get install -yqq --no-install-recommends \
     && /build/install/wkhtmltopdf-${WKHTMLTOPDF_VERSION}.sh \
     && /build/install/postgres-client.sh \
-    && rm -rf /tmp/* \
-    && sync
+    && rm -rf /tmp/*
 
 # Install and build Odoo dependencies
 ARG ODOO_VERSION=master
@@ -61,8 +60,7 @@ RUN --mount=type=bind,src=build/install/${DISTRIBUTION}/apt-build-deps.txt,dst=/
     && xargs -a /build/apt-build-deps.txt apt-get purge -yqq \
     && apt-get autopurge -yqq \
     && rm -rf /tmp/* \
-    && rm -rf /build/odoo-requirements.txt \
-    && sync
+    && rm -rf /build/odoo-requirements.txt
 
 # Install GeoIP database (optional)
 # The LOCAL_GEOIP_PATH is used to specify the path to the GeoIP database files
@@ -84,8 +82,7 @@ RUN useradd -md /home/odoo -s /bin/false odoo \
     && mkdir -p $REPOSITORIES \
     && mkdir -p $DATA_DIR \
     && mkdir -p $RESOURCES \
-    && chown -R odoo:odoo /home/odoo \
-    && sync
+    && chown -R odoo:odoo /home/odoo
 
 # Entrypoint scripts
 COPY --chmod=777 bin/* /usr/local/bin/


### PR DESCRIPTION
## Summary

Removes the `sync` calls trailing the build `RUN` steps in the Dockerfile.

`sync` flushes the OS filesystem buffers to disk, but this does nothing useful for Docker layer integrity — the layer is committed by the builder regardless, and the build cache/layer content is unaffected by whether dirty pages have been flushed. The calls are pointless and just add noise.

## Changes

- Drop `&& sync` from the system-deps install layer (line 34)
- Drop `&& sync` from the Odoo deps build layer (line 65)
- Drop `&& sync` from the user/directory setup layer (line 88)