### PR TITLE
⬆️ bump postgres to 15 in test compose

### DIFF
--- a/tests/compose.yaml
+++ b/tests/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:12
+    image: postgres:15
     environment:
       POSTGRES_USER: odoo
       POSTGRES_PASSWORD: odoo


### PR DESCRIPTION
## What

Bump the Postgres image in `tests/compose.yaml` from `postgres:12` to `postgres:15`.

## Why

Postgres 12 is end-of-life. The README example already uses `postgres:15`, so this aligns the test environment with the documented setup.