### PR TITLE
📝 fix odoo.sh link in README rendering as relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ volumes:
 ### Directory structure
 
 Basically, every directory you have to worry about is found inside `/home/odoo`.
-The directory structure is similar to [odoo.sh](odoo.sh), but not exactly the
+The directory structure is similar to [odoo.sh](https://www.odoo.sh), but not exactly the
 same. This is the structure:
 
     src/


### PR DESCRIPTION
## Description

The `odoo.sh` link in the README rendered as a relative link because the URL was missing its scheme:

```markdown
[odoo.sh](odoo.sh)
```

This made it point to a non-existent relative path instead of the actual site. Fixed by using the full URL:

```markdown
[odoo.sh](https://www.odoo.sh)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)